### PR TITLE
fix: 콘스턴트 모드 GIF 플레이스홀더 적용 (fixes #5)

### DIFF
--- a/src/components/main/WeightModes.tsx
+++ b/src/components/main/WeightModes.tsx
@@ -15,7 +15,8 @@ const iconMap: Record<string, LucideIcon> = {
 
 // 각 모드 시연용 운동 GIF
 const modeGifs: Record<string, string> = {
-  constant: "/roomfit/exercise-deadlift-back.gif",
+  // TODO: exercise-deadlift-back.gif 에셋 확보 후 교체 필요 (임시 placeholder)
+  constant: "/roomfit/exercise-barbell-row-white.gif",
   negative: "/roomfit/exercise-concentration-curl.gif",
   squeeze: "/roomfit/exercise-squat-barbell.gif",
   isokinetic: "/roomfit/exercise-barbell-curl.gif",


### PR DESCRIPTION
## 변경사항
- 콘스턴트 모드 GIF를 `exercise-barbell-row-white.gif`로 임시 교체
- 원본 `exercise-deadlift-back.gif` 에셋 확보 후 교체 필요 (TODO 코멘트 추가)

Closes #5